### PR TITLE
56 feat permitir agregar texto alternativo a las imagenes en sanity

### DIFF
--- a/studio/schemas/image.ts
+++ b/studio/schemas/image.ts
@@ -1,0 +1,17 @@
+export default {
+  name: "img",
+  options: { hotspot: true },
+  type: "image",
+  fields: [
+    {
+      name: "alt_text",
+      title: "Texto alternativo",
+      type: "string",
+      options: { isHighlighted: true },
+      validation: (Rule: any) =>
+        Rule.required().error(
+          "Las imágenes deben contener un texto alternativo"
+        ),
+    },
+  ],
+};

--- a/studio/schemas/member.ts
+++ b/studio/schemas/member.ts
@@ -45,10 +45,7 @@ export default {
     {
       name: "image",
       title: "Avatar",
-      type: "image",
-      options: {
-        hotspot: true,
-      },
+      type: "img",
     },
   ],
   preview: {

--- a/studio/schemas/schema.ts
+++ b/studio/schemas/schema.ts
@@ -8,6 +8,7 @@ import schemaTypes from "all:part:@sanity/base/schema-type";
 import document from "./document";
 import documents from "./documents";
 import faq from "./faq";
+import image from "./image";
 import member from "./member";
 import toy from "./toy";
 
@@ -22,6 +23,7 @@ export default createSchema({
     document,
     documents,
     faq,
+    image,
     member,
     toy,
   ]),

--- a/studio/schemas/toy.ts
+++ b/studio/schemas/toy.ts
@@ -38,18 +38,11 @@ export default {
       description: "Completar con la descripción del juguete.",
     },
     {
-      name: "imagesGallery",
+      name: "images",
       type: "array",
       title: "Imágenes del juguete.",
       description: "Incluir imágenes del juguete.",
-      of: [
-        {
-          type: "image",
-          options: {
-            hotspot: true,
-          },
-        },
-      ],
+      of: [{ title: "Imagen", type: "img" }],
     },
     {
       name: "available",

--- a/studio/schemas/toy.ts
+++ b/studio/schemas/toy.ts
@@ -82,7 +82,7 @@ export default {
         {
           ...baseObject,
           name: "rightMvt",
-          title: "Movimiento hacia la izquierda",
+          title: "Movimiento hacia la derecha",
         },
         {
           ...baseObject,


### PR DESCRIPTION
# Issue: #56 

- Resuelve issue #56

## Qué tipo de PR es esta? (marcar las que correspondan)

- [X] Refactor.
<!-- Modificación de código existente -->

- [X] Nueva funcionalidad.
<!-- Introducción de nueva funcionalidad / Feature -->

- [ ] Corrección de error/es.
<!-- Corrección de errores / Bug fix -->

- [ ] Optimización.
<!-- Cambios relacionados a performance -->

- [ ] Actualización/extensión de documentación.
<!-- Cambios en la documentación / Documentation related. -->

## Descripción

- Se agrego un nuevo schema reutilizable para imagenes con un texto alternativo (texto siempre requerido).

### Pasos necesarios para testear/visualizar los cambios implementados:

1. Ejecutar `yarn sanity`
2. Se puede visualizar en "Team Member" o "Juguete"

## Archivos modificados/creados:

- [Files changed]()

## Capturas de pantalla/videos:

- [ ] Nuevo componente.
<!-- Incluir capturas de pantalla en diferentes dispositivos -->

- [X] Modificación a elemento de User Interface.
<!-- Incluir captura con estado previo y posterior a la modificación indicando cuál corresponde a cada una. -->

- [ ] No aplica.
<!-- En el caso de que sea un refactor a la lógica por ejemplo. -->

![image](https://user-images.githubusercontent.com/78808163/202875501-8fb609b2-9203-4cfe-8f8b-55339a358808.png)
