### PR TITLE
feat: add the category name as subtitle in characteristics preview

### DIFF
--- a/studio/schemas/characteristics.ts
+++ b/studio/schemas/characteristics.ts
@@ -18,4 +18,10 @@ export default {
       to: [{ type: "characteristics_list" }],
     },
   ],
+  preview: {
+    select: {
+      title: "characteristic_name",
+      subtitle: "characteristics_category.characteristics_list_name",
+    },
+  },
 };


### PR DESCRIPTION
# Issue:

Closes #66 

## Qué tipo de PR es esta? (marcar las que correspondan)

- [ ] Refactor.
- [ ] Nueva funcionalidad.
- [ ] Corrección de error/es.
- [x] Optimización.
- [ ] Actualización/extensión de documentación.

## Descripción

Añade una [custom list preview](https://www.sanity.io/docs/previews-list-views#dcbbdb0ec3aa) al esquema de características, usando el título de la categoría como subtítulo de la preview

### Links:

https://www.sanity.io/docs/previews-list-views#dcbbdb0ec3aa

### Pasos necesarios para testear/visualizar los cambios implementados:

1. Ir al directorio `/studio` dentro del proyecto
2. Ejecutar `yarn run start`
3. Ir a _Juguete_ en el listado de esquemas
4. Al crear un nuevo juguete, en el listado de características se debería ver la categoría
como subtítulo de cada elemento (ver img)

<img width="694" alt="imagen" src="https://user-images.githubusercontent.com/4043417/208246961-8121b18e-4c46-4387-bf33-22eadea58d6c.png">

## Archivos modificados/creados:

- `studio/schemas/characteristics.ts`

## Capturas de pantalla/videos:

- [ ] Nuevo componente.
- [ ] Modificación a elemento de User Interface.
- [X] No aplica.
