### PR TITLE
 feat(husky): add types check in pre-commit hook 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,6 +7,9 @@ yarn lint-staged
 # Run eslint
 yarn run lint --cache
 
+# Run tsc (check types)
+yarn run tsc
+
 # Colors
 red='\033[0;31m'
 green='\033[0;32m'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "sanity": "yarn workspace sanity-studio start",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -o .sb",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "husky install"
   },
   "dependencies": {
     "@next/font": "^13.1.0",


### PR DESCRIPTION
# Issue:

Resuelve issue #111

## Qué tipo de PR es esta? (marcar las que correspondan)

- [x] Nueva funcionalidad.
<!-- Introducción de nueva funcionalidad / Feature -->

## Descripción

Ya que `next lint` no realiza chequeo de tipos se añade `yarn run tsc` al `pre-commit` hook para evitar crear commits con errores de tipado


### Pasos necesarios para testear/visualizar los cambios implementados:

Añadir un error en el tipado (por ejemplo hacer nullable una variable que no debería serlo), tratar de hacer un commit y verificar que se muestra el error

<img width="1198" alt="imagen" src="https://user-images.githubusercontent.com/4043417/209866235-85d60f87-6ae4-4db7-b7e9-10ad49c8669e.png">

## Archivos modificados/creados:

- `.husky/pre-commit`