### PR TITLE
[REFACTOR] moved document schema to schemas/

### DIFF
--- a/schemas/document.ts
+++ b/schemas/document.ts
@@ -1,0 +1,28 @@
+import { DocumentIcon } from "@sanity/icons";
+import { defineField, defineType } from "sanity";
+
+const document = defineType({
+  name: "doc",
+  title: "Documento",
+  type: "document",
+  icon: DocumentIcon,
+  fields: [
+    defineField({
+      name: "title",
+      title: "Titulo",
+      type: "string",
+    }),
+    defineField({
+      name: "description",
+      title: "Descripción",
+      type: "string",
+    }),
+    defineField({
+      name: "file",
+      title: "Archivo",
+      type: "file",
+    }),
+  ],
+});
+
+export default document;

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -1,11 +1,11 @@
 // TODO: Migrate schemas from './studio/schemas' to './schemas'
 import characteristics_list from "schemas/characteristics_list";
+import document from "schemas/document";
 import about from "studio/schemas/about";
 import accessibilityDeclaration from "studio/schemas/accessibility-declaration";
 import block from "studio/schemas/block";
 import characteristics from "studio/schemas/characteristics";
 import collaborate from "studio/schemas/collaborate";
-import document from "studio/schemas/document";
 import documents from "studio/schemas/documents";
 import faq from "studio/schemas/faq";
 import homePage from "studio/schemas/home-page";


### PR DESCRIPTION
## Issues relacionados.

- Resuelve issue #154 

## Que implementa o corrige este Pull Request.
Se mueve el esquema [document.ts](https://github.com/Juguetear/juguetear-web/blob/bfa4199217ae6ef21bb82b7e3bafacc7f585f7e0/studio/schemas/document.ts) que estaba en el directorio [studio/schemas/](https://github.com/Juguetear/juguetear-web/blob/b76d0f755795b94950a8d35127625f1c60c23870/studio/schemas), al directorio [schemas/](https://github.com/Juguetear/juguetear-web/blob/b76d0f755795b94950a8d35127625f1c60c23870/schemas) y se corrige la importación en el archivo [schemas/index.ts](https://github.com/Juguetear/juguetear-web/blob/b76d0f755795b94950a8d35127625f1c60c23870/schemas/index.ts).

tambien se refactoriza el esquema, para utilizar las [funciones helper](https://www.sanity.io/docs/schema-field-types) de santity v3

### Tipo de Pull Request:

- [x] Refactor (Modificación de código existente).

### Pasos necesarios para probar/visualizar los cambios implementados:

No aplica

### Capturas de pantalla/videos:

- [x] No aplica.

---

## Código de conducta y contribuir.

- [x] He leído seguir el [código de conducta][doc-code_of_conduct] de este proyecto.
- [x] He leído seguir las normas de [cómo contribuir][doc-contributing] a este proyecto.