### PR TITLE
#208 ADD query ByTestId, test para ver si esta el attr aria-hidden y REMOV…

### DIFF
--- a/components/IconError/IconError.test.tsx
+++ b/components/IconError/IconError.test.tsx
@@ -1,9 +1,15 @@
-import "@testing-library/jest-dom/extend-expect";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import { IconError } from "./IconError";
 
 test("IconError className prop render", () => {
-  const { container } = render(<IconError className="fill-red" />);
-  expect(container.getElementsByClassName("fill-red")).toHaveLength(1);
+  render(<IconError className="fill-red" />);
+  const svgElement = screen.getByTestId("fill-red");
+  expect(svgElement).toBeInTheDocument();
+});
+
+test("IconError has aria-hidden attribute", () => {
+  render(<IconError className="fill-red" />);
+  const svgElement = screen.getByTestId("fill-red");
+  expect(svgElement).toHaveAttribute("aria-hidden", "true");
 });

--- a/components/IconError/IconError.tsx
+++ b/components/IconError/IconError.tsx
@@ -6,6 +6,7 @@ export const IconError = ({ className }: IconErrorProps) => {
   return (
     <svg
       aria-hidden="true"
+      data-testid={className}
       width="13"
       height="13"
       viewBox="0 0 512.000000 512.000000"


### PR DESCRIPTION
## Issues relacionados.

- Resuelve issue #208

## Que implementa o corrige este Pull Request.

Removi la funcion "getElementsByClassName" y como pedia usar un metodo de la libreria use una Query que se llama ByTestId donde se le agrega un atributo al elemento svg y despues obtengo el elemento con ese atributo

### Lista los links a documentación, recursos, etc que estén relacionados:

- [byTestId](https://testing-library.com/docs/queries/bytestid/)

### Tipo de Pull Request:

- [x] Refactor (Modificación de código existente).
- [ ] New feature (Introducción de nueva funcionalidad).
- [ ] Bug fix (Corrección de error/es)
- [ ] Performance (Mejoras de optimización).
- [ ] Docs (Actualización/extensión de documentación).

### Pasos necesarios para probar/visualizar los cambios implementados:

1. Correr `yarn lint` para comprobar que no esten mas los errores
2. Correr `yarn test` para comprobar que los test pasen correctamente

### Capturas de pantalla/videos:

- [ ] Nuevo componente. <!-- Incluir capturas de pantalla en diferentes dispositivos -->
- [ ] Modificación a elemento en la interfaz de usuario. <!-- Incluir captura con estado previo y posterior a la modificación. -->
- [ ] No aplica.

---

## Código de conducta y contribuir.

:warning: Antes de realizar el Pull Request, por favor asegúrate de haber leído el [código de conducta][doc-code_of_conduct] y [cómo contribuir][doc-contributing].

- [x] He leído seguir el [código de conducta][doc-code_of_conduct] de este proyecto.
- [x] He leído seguir las normas de [cómo contribuir][doc-contributing] a este proyecto.

> ⛑️ En caso de que necesites ayuda o tengas alguna duda recordá que también podés preguntar en el canal [#juguetear][dc-channel] dentro de la comunidad [FrontendCafé][dc-fec] en Discord. El código de conducta de este proyecto es extensible también a tu participación en el server de [FrontendCafé][dc-fec].

<!-- Listado de enlaces de referencia, mantenerlos actualizados en cada archivo -->
<!-- Enlaces a archivos de documentación (propios al repositorio)  -->

[doc-code_of_conduct]: CODE_OF_CONDUCT.md
[doc-contributing]: CONTRIBUTING.md

<!-- Enlaces a Discord -->

[dc-channel]: https://discord.com/channels/594363964499165194/1035685740409012244
[dc-fec]: https://discord.com/invite/frontendcafe
