### PR TITLE
fix: Position of the error icon in textarea component in Firefox

### DIFF
--- a/components/TextArea/TextArea.tsx
+++ b/components/TextArea/TextArea.tsx
@@ -35,11 +35,11 @@ const TextArea = ({
    disabled:ring-gray-dark disabled:bg-gray-light ${
      error ? "ring-2 ring-red font-bold" : "ring-blue"
    } `;
-  const svgStyles = `absolute right-5 top-11 ${error ? "block" : "hidden"}`;
+  const svgStyles = `absolute right-6 top-14 ${error ? "block" : "hidden"}`;
 
   return (
     <div className="group space-y-1 font-inter text-base">
-      <label htmlFor={id} className="relative">
+      <label htmlFor={id} className="block">
         <span className={spanStyles}>
           {required ? "*" : ""}
           {label}


### PR DESCRIPTION
## Issues relacionados.

- Resuelve issue #398

## Que implementa o corrige este Pull Request.

Corrige la posición del icono de error en el textarea que inicialmente aparecía a la izquierda en Firefox a diferencia de Chrome. Ahora en ambos navegadores el icono de error del textarea aparece arriba a la derecha

### Tipo de Pull Request:

- [ ] Refactor (Modificación de código existente).
- [ ] New feature (Introducción de nueva funcionalidad).
- [x] Bug fix (Corrección de error/es)
- [ ] Performance (Mejoras de optimización).
- [ ] Docs (Actualización/extensión de documentación).

### Pasos necesarios para probar/visualizar los cambios implementados:

1. Ejecutar npm run storybook
2. Ver el componente TextArea tanto con Firefox como con Chrome

### Capturas de pantalla/videos:

![image](https://github.com/user-attachments/assets/435c5db1-246a-424e-8be6-4052c9ac55fb)

---

## Código de conducta y contribuir.

:warning: Antes de realizar el Pull Request, por favor asegúrate de haber leído el [código de conducta][doc-code_of_conduct] y [cómo contribuir][doc-contributing].

- [x] He leído seguir el [código de conducta][doc-code_of_conduct] de este proyecto.
- [x] He leído seguir las normas de [cómo contribuir][doc-contributing] a este proyecto.
